### PR TITLE
feat: add simple authentication modal

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -10,7 +10,19 @@ jest.mock('date-fns/locale', () => ({ ptBR: {} }));
 
 import App from './App';
 
-test('exibe título do progresso do usuário', () => {
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test('mostra modal de autenticação quando usuário não está logado', () => {
+  render(<App />);
+  expect(screen.getByText(/Login/i)).toBeInTheDocument();
+});
+
+test('exibe título do progresso quando usuário está logado', () => {
+  localStorage.setItem('currentUser', JSON.stringify('user'));
+  localStorage.setItem('habits_user', JSON.stringify([]));
+  localStorage.setItem('xp_user', JSON.stringify(0));
   render(<App />);
   const heading = screen.getByText(/Meu Progresso/i);
   expect(heading).toBeInTheDocument();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,8 @@ import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ResponsiveContai
 import { format, subDays, isToday } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import './App.css';
-import { loadFromStorage, saveToStorage } from './utils/storage';
-import AuthModal from './AuthModal';
+import { loadFromStorage, saveToStorage } from './utils/storage.ts';
+import AuthModal from './AuthModal.tsx';
 
 type Habit = {
   id: string;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { format, subDays, isToday } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import './App.css';
 import { loadFromStorage, saveToStorage } from './utils/storage';
+import AuthModal from './AuthModal';
 
 type Habit = {
   id: string;
@@ -28,31 +29,29 @@ const CATEGORIES = ['Saúde', 'Aprendizado', 'Produtividade', 'Mental', 'Físico
 const generateHabitId = () => Math.random().toString(36).substring(2, 15);
 
 const App = () => {
-  const [habits, setHabits] = useState<Habit[]>(() =>
-    loadFromStorage('habits', [])
+  const [user, setUser] = useState<string | null>(() =>
+    loadFromStorage('currentUser', null)
   );
-
+  const [habits, setHabits] = useState<Habit[]>([]);
   const [dailyProgress, setDailyProgress] = useState<DailyProgress[]>([]);
-  const [xp, setXp] = useState(() => loadFromStorage('xp', 0));
+  const [xp, setXp] = useState(0);
   const [newHabit, setNewHabit] = useState({ name: '', category: CATEGORIES[0] });
   const [activeTab, setActiveTab] = useState('habits');
 
-  // Carregar dados iniciais
   useEffect(() => {
-    if (habits.length === 0) {
-      const initialHabits: Habit[] = [];
-      setHabits(initialHabits);
+    if (user) {
+      setHabits(loadFromStorage(`habits_${user}`, []));
+      setXp(loadFromStorage(`xp_${user}`, 0));
     }
+  }, [user]);
 
-    generateProgressData();
-  }, []);
-
-  // Persistir dados
   useEffect(() => {
-    saveToStorage('habits', habits);
-    saveToStorage('xp', xp);
-    generateProgressData();
-  }, [habits, xp]);
+    if (user) {
+      saveToStorage(`habits_${user}`, habits);
+      saveToStorage(`xp_${user}`, xp);
+      generateProgressData();
+    }
+  }, [habits, xp, user]);
 
   function generateHistory(streak: number, completed: boolean, todayCompleted = false) {
     const history = [];
@@ -147,6 +146,11 @@ const App = () => {
 
   const calculateLevel = () => Math.floor(xp / 100);
   const levelProgress = xp % 100;
+
+  const handleLogin = (username: string) => {
+    setUser(username);
+    saveToStorage('currentUser', username);
+  };
 
   return (
     <div className="app">
@@ -379,6 +383,7 @@ const App = () => {
       <footer className="app-footer">
         <p>Desenvolvido para crescimento pessoal • {format(new Date(), 'dd/MM/yyyy')}</p>
       </footer>
+      {!user && <AuthModal onLogin={handleLogin} />}
     </div>
   );
 };

--- a/src/AuthModal.tsx
+++ b/src/AuthModal.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import { loadFromStorage, saveToStorage } from './utils/storage';
+
+type AuthModalProps = {
+  onLogin: (username: string) => void;
+};
+
+const AuthModal: React.FC<AuthModalProps> = ({ onLogin }) => {
+  const [isRegister, setIsRegister] = useState(false);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = () => {
+    const users = loadFromStorage<Record<string, { password: string }>>('users', {});
+
+    if (!username || !password) {
+      setError('Preencha todos os campos');
+      return;
+    }
+
+    if (isRegister) {
+      if (users[username]) {
+        setError('Usuário já existe');
+        return;
+      }
+      users[username] = { password };
+      saveToStorage('users', users);
+      saveToStorage(`habits_${username}`, []);
+      saveToStorage(`xp_${username}`, 0);
+      onLogin(username);
+    } else {
+      if (!users[username] || users[username].password !== password) {
+        setError('Credenciais inválidas');
+        return;
+      }
+      onLogin(username);
+    }
+  };
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal">
+        <h2>{isRegister ? 'Registro' : 'Login'}</h2>
+        <input
+          type="text"
+          placeholder="Usuário"
+          value={username}
+          onChange={e => setUsername(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Senha"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        {error && <p className="error">{error}</p>}
+        <button onClick={handleSubmit}>{isRegister ? 'Registrar' : 'Entrar'}</button>
+        <button className="link" onClick={() => { setIsRegister(!isRegister); setError(''); }}>
+          {isRegister ? 'Já possui conta? Entre' : 'Criar conta'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AuthModal;

--- a/src/AuthModal.tsx
+++ b/src/AuthModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { loadFromStorage, saveToStorage } from './utils/storage';
+import { loadFromStorage, saveToStorage } from './utils/storage.ts';
 
 type AuthModalProps = {
   onLogin: (username: string) => void;

--- a/src/index.css
+++ b/src/index.css
@@ -233,6 +233,7 @@ body {
   border-radius: 16px;
   padding: 1.5rem;
   margin-bottom: 1.5rem;
+  margin-left: -75px;
 }
 
 .progress-summary {

--- a/src/index.css
+++ b/src/index.css
@@ -377,3 +377,52 @@ body {
     padding: 0.5rem;
   }
 }
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background-color: var(--card-bg);
+  padding: 2rem;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  max-width: 320px;
+}
+
+.modal input {
+  padding: 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background-color: var(--background);
+  color: var(--text);
+}
+
+.modal button {
+  padding: 0.75rem;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.modal button.link {
+  background: none;
+  color: var(--primary);
+  text-decoration: underline;
+}
+
+.modal .error {
+  color: var(--danger);
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- require users to login or register before accessing the app
- persist habit and XP data per user in localStorage
- add tests for authentication flow

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893ab6ea79c83219cc5761d470a672e