### PR TITLE
Implement habit day rollover and streak reset

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,14 +1,8 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-
-jest.mock('date-fns', () => ({
-  format: () => 'Mon',
-  subDays: (date: Date) => date,
-  isToday: () => false
-}));
-jest.mock('date-fns/locale', () => ({ ptBR: {} }));
-
 import App from './App';
+
+jest.mock('date-fns/locale', () => ({ ptBR: undefined }));
 
 beforeEach(() => {
   localStorage.clear();
@@ -40,4 +34,31 @@ test('carrega hábitos e xp do usuário logado', async () => {
 
   expect(await screen.findByText('Ler')).toBeInTheDocument();
   expect(screen.getByText(/20 XP/)).toBeInTheDocument();
+});
+
+test('reseta streak quando hábito não foi completado no dia anterior', async () => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2023-01-02'));
+
+  const habits = [
+    {
+      id: '1',
+      name: 'Correr',
+      streak: 3,
+      completed: false,
+      history: [{ date: '2023-01-01', completed: false }],
+      category: 'Saúde'
+    }
+  ];
+
+  localStorage.setItem('currentUser', JSON.stringify('user'));
+  localStorage.setItem('habits_user', JSON.stringify(habits));
+  localStorage.setItem('xp_user', JSON.stringify(0));
+
+  render(<App />);
+
+  expect(await screen.findByText('Correr')).toBeInTheDocument();
+  expect(screen.getByText('🔥 0 dias')).toBeInTheDocument();
+
+  jest.useRealTimers();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,6 +57,32 @@ const App = () => {
     }
   }, [habits, xp, user, dataLoaded]);
 
+  useEffect(() => {
+    if (dataLoaded) {
+      const today = format(new Date(), 'yyyy-MM-dd');
+      const yesterday = format(subDays(new Date(), 1), 'yyyy-MM-dd');
+
+      setHabits(prev =>
+        prev.map(habit => {
+          const lastEntry = habit.history[habit.history.length - 1];
+          if (lastEntry?.date === today) {
+            return { ...habit, completed: lastEntry.completed };
+          }
+
+          const missedYesterday =
+            !lastEntry || lastEntry.date !== yesterday || !lastEntry.completed;
+
+          return {
+            ...habit,
+            streak: missedYesterday ? 0 : habit.streak,
+            completed: false,
+            history: [...habit.history, { date: today, completed: false }]
+          };
+        })
+      );
+    }
+  }, [dataLoaded]);
+
   function generateHistory(streak: number, completed: boolean, todayCompleted = false) {
     const history = [];
     const today = new Date();


### PR DESCRIPTION
## Summary
- reset habit streak and completion state when a new day starts or yesterday was missed
- add test ensuring streak resets after a missed day

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6893b26285a48321bfa7c1b586f20bac